### PR TITLE
Does not set session on auth token retrieval failure

### DIFF
--- a/App/Components/Main.js
+++ b/App/Components/Main.js
@@ -21,9 +21,11 @@ export default class Main extends React.Component {
 
   checkForKey() {
     store.get('session').then((session) => {
-      this.setState({
-        auth_token: session.token
-      });
+      if (session) {
+        this.setState({
+          auth_token: session.token
+        });
+      }
     });
   }
   render() {

--- a/App/Components/Settings.js
+++ b/App/Components/Settings.js
@@ -38,10 +38,12 @@ export default class Settings extends React.Component {
 
   componentDidMount() {
     store.get('session').then((res) => {
-      this.setState({
-        firstName: res.user.first_name,
-        lastName: res.user.last_name,
-      });
+      if (res) {
+        this.setState({
+          firstName: res.user.first_name,
+          lastName: res.user.last_name,
+        });
+      }
     });
   }
 

--- a/App/Lib/Api.js
+++ b/App/Lib/Api.js
@@ -20,10 +20,12 @@ const api = {
     .then((res) => {
       const resBody = JSON.parse(res._bodyText);
 
-      store.save('session', {
-        token: resBody.auth_token,
-        current_user: resBody.user,
-      });
+      if (res.status < 400) {
+        store.save('session', {
+          token: resBody.auth_token,
+          current_user: resBody.user,
+        });
+      }
 
       return resBody;
     })


### PR DESCRIPTION
- Added conditional check on the API's `setToken()` method.  Does not change `session` if the API returns an error.
- Similarly, added conditional checks on `Settings` and `Main` components when `store.get('session')` returns null.