### PR TITLE
A more precise check for a successful POST response from fetch

### DIFF
--- a/App/Lib/Api.js
+++ b/App/Lib/Api.js
@@ -19,7 +19,7 @@ const api = {
     return fetch(url, params).then((res) => {
       const resBody = JSON.parse(res._bodyText);
 
-      if (res.status < 400) {
+      if (res.ok) {
         store.save('session', {
           token: resBody.auth_token,
           current_user: resBody.user,


### PR DESCRIPTION
For a POST response, instead of checking to see if the response status is less than 400, it is probably more precise to check if the response status falls in the range of 200-299. The web API has a response property `response.ok` that returns a boolean if the POST, GET, PUT, or DELETE was successful within the 200-299 range. 

The attached link explains https://developer.mozilla.org/en-US/docs/Web/API/Response/ok

Might want to also see the `fetch` documentation on this as well https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch