### PR TITLE
15 add markdown rendering

### DIFF
--- a/App/Components/MessageThreads.js
+++ b/App/Components/MessageThreads.js
@@ -15,6 +15,7 @@ import api from './../Lib/Api';
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
     height: 500,
     marginTop: 65,
   },

--- a/App/Components/__tests__/Main.test.js
+++ b/App/Components/__tests__/Main.test.js
@@ -1,0 +1,13 @@
+import React, {Text, TextInput, TouchableHighlight} from 'react-native';
+import {shallow} from 'enzyme';
+import Main from '../Main';
+import {expect} from 'chai';
+
+describe('<Main />', () => {
+  it('should render Main component', () => {
+    const component = shallow(<Main />);
+    expect(component).to.exists
+  });
+});
+
+

--- a/App/Components/__tests__/MessagesThreads.test.js
+++ b/App/Components/__tests__/MessagesThreads.test.js
@@ -1,0 +1,13 @@
+import React, {Text, TextInput, TouchableHighlight} from 'react-native';
+import {shallow} from 'enzyme';
+import MessageThreads from '../MessageThreads';
+import {expect} from 'chai';
+
+describe('<MessageThreads />', () => {
+  it('should render MessageThreads component', () => {
+    const component = shallow(<MessageThreads />);
+    expect(component).to.exists
+  });
+});
+
+

--- a/App/Components/__tests__/NewMessageForm.test.js
+++ b/App/Components/__tests__/NewMessageForm.test.js
@@ -1,0 +1,13 @@
+import React, {Text, TextInput, TouchableHighlight} from 'react-native';
+import {shallow} from 'enzyme';
+import NewMessageForm from '../NewMessageForm';
+import {expect} from 'chai';
+
+describe('<NewMessageForm />', () => {
+  it('should render NewMessageForm', () => {
+    const component = shallow(<NewMessageForm />);
+    expect(component).to.exists
+  });
+});
+
+

--- a/App/Components/__tests__/Settings.test.js
+++ b/App/Components/__tests__/Settings.test.js
@@ -1,0 +1,13 @@
+import React, {Text, TextInput, TouchableHighlight} from 'react-native';
+import {shallow} from 'enzyme';
+import Settings from '../Settings';
+import {expect} from 'chai';
+
+describe('<Settings />', () => {
+  it('should render Settings component', () => {
+    const component = shallow(<Settings />);
+    expect(component).to.exists
+  });
+});
+
+

--- a/App/Components/__tests__/ViewMessages.test.js
+++ b/App/Components/__tests__/ViewMessages.test.js
@@ -1,0 +1,12 @@
+import React, {Text, TextInput, TouchableHighlight} from 'react-native';
+import {shallow} from 'enzyme';
+import ViewMessages from '../ViewMessages';
+import {expect} from 'chai';
+
+describe('<ViewMessages />', () => {
+  it('should render ViewMessages component', () => {
+    const component = shallow(<ViewMessages />);
+    expect(component).to.exists
+  });
+});
+

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "react": "^0.14.8",
     "react-addons-test-utils": "^0.14.8",
     "react-dom": "^0.14.8",
-    "react-native-mock": "0.0.6"
+    "react-native-mock": "0.0.7"
   }
 }


### PR DESCRIPTION
This closes #20 Messages getting cutoff.

I just needed to add `flex: 1` to fill the screen

Before:
<img width="495" alt="screenshot 2016-04-20 07 11 06" src="https://cloud.githubusercontent.com/assets/5713670/14678673/8c945fe8-06cb-11e6-8723-e3f0e6bc62f1.png">


After: 

<img width="420" alt="screenshot 2016-04-20 07 10 49" src="https://cloud.githubusercontent.com/assets/5713670/14678671/8b4541f2-06cb-11e6-85dc-0a5c44d54523.png">


Also, Testing was broken and fixed in [react-native-mock](https://github.com/lelandrichardson/react-native-mock/issues/12). I upgrade the version to include their fix. 

I then wrote a smoke test for all components, and have plans to write more extensive unit test in the future.